### PR TITLE
Fix: db 장르 매핑 오류 수정

### DIFF
--- a/src/main/java/com/storix/storix_api/domains/works/domain/Genre.java
+++ b/src/main/java/com/storix/storix_api/domains/works/domain/Genre.java
@@ -16,7 +16,10 @@ public enum Genre {
     GAG("개그"),
     THRILLER("스릴러"),
     ACTION("액션"),
-    SPORTS("스포츠");
+    SPORTS("스포츠"),
+    SENTIMENTAL("감성"),
+    BL("BL"),
+    MODERN_FANTASY("현판");
 
     private final String dbValue;
 }


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
- enum 값 불일치로 인한 오류 수정하였습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
## 🖇️ 기타