### PR TITLE
Fix: 닉네임 중복체크 API REST & Validation 컨플릭트 수정

### DIFF
--- a/src/main/java/com/storix/storix_api/domains/user/controller/AuthController.java
+++ b/src/main/java/com/storix/storix_api/domains/user/controller/AuthController.java
@@ -10,11 +10,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -60,10 +65,17 @@ public class AuthController {
     @Operation(summary = "닉네임 중복 체크", description = "닉네임 중복 여부를 체크하는 api 입니다.")
     @GetMapping("/nickname/valid")
     public ResponseEntity<CustomResponse<Void>> nickNameCheck(
-            @Valid @RequestBody NickNameCheckRequest req
+            @RequestParam("nickname")
+            @NotBlank(message = "닉네임은 필수입니다.")
+            @Size(min = 2, max = 10, message = "닉네임은 2~10자까지 가능합니다.")
+            @Pattern(
+                    regexp = "^(?=.*[가-힣a-zA-Z0-9])[가-힣a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ ]+$",
+                    message = "닉네임은 한글, 영문, 숫자, 공백만 가능하며 자음/모음/공백만으로는 불가능합니다."
+            )
+            String nickName
     ) {
         return ResponseEntity.ok()
-                .body(authUseCase.checkAvailableNickname(req.nickName()));
+                .body(authUseCase.checkAvailableNickname(nickName));
     }
 
     @Operation(summary = "작가 계정 일반 로그인", description = "작가 계정에 로그인 하는 api 입니다.")

--- a/src/main/java/com/storix/storix_api/global/apiPayload/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/storix/storix_api/global/apiPayload/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.storix.storix_api.global.apiPayload.exception;
 
 import com.storix.storix_api.global.apiPayload.code.ErrorCode;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
@@ -39,6 +40,25 @@ public class GlobalExceptionHandler {
                                 fe.getDefaultMessage()
                         ))
                         .toList();
+
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+        ErrorResponse response = new ErrorResponse(errorCode, fieldErrors);
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+
+        List<FieldErrorResponse> fieldErrors = e.getConstraintViolations().stream()
+                .map(v -> FieldErrorResponse.builder()
+                        .field(v.getPropertyPath().toString())
+                        .rejectedValue(v.getInvalidValue())
+                        .reason(v.getMessage())
+                        .build())
+                .toList();
 
         ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
         ErrorResponse response = new ErrorResponse(errorCode, fieldErrors);


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [x] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
닉네임 중복체크 API 가 GET 방식이나, Validation 방식의 정합성 체크를 위해 RequestParam -> RequestBody로 변경하였었습니다. 해당 코드로 인해서 API 호출 시 ConstraintViolationException 이 발생하고 있었습니다. AuthController에 Validation 어노테이션을 추가하였으며 RequestParam으로 다시 변경해두었습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #30 

## 🖇️ 기타