### PR TITLE
Refactor: 피드 댓글 domain 엔티티 글자수 제한 추가

### DIFF
--- a/src/main/java/com/storix/storix_api/domains/feed/domain/BoardReply.java
+++ b/src/main/java/com/storix/storix_api/domains/feed/domain/BoardReply.java
@@ -18,7 +18,7 @@ public abstract class BoardReply extends BaseTimeEntity {
     @Column(name = "user_id", nullable = false)
     protected Long userId;
 
-    @Column(name = "comment", nullable = false)
+    @Column(length = 300, nullable = false)
     protected String comment;
 
     @Column(name = "like_count", nullable = false)


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 피드 댓글 엔티티 컬럼 제약
- 피드 댓글 300자 제한을 엔티티 단에도 컬럼 제약을 두도록 수정하였습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #61 

## 🖇️ 기타