### PR TITLE
Fix: 리뷰 단건 조회 관련 userId 변경

### DIFF
--- a/src/main/java/com/storix/storix_api/domains/plus/application/service/ReviewService.java
+++ b/src/main/java/com/storix/storix_api/domains/plus/application/service/ReviewService.java
@@ -139,7 +139,7 @@ public class ReviewService {
 
         // 2) 프로필 정보
         StandardProfileInfo profile =
-                userAdaptor.findStandardProfileInfoByUserId(userId);
+                userAdaptor.findStandardProfileInfoByUserId(reviewInfo.reviewerId());
 
         // 3) 작품 정보
         Long worksId = reviewInfo.worksId();


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 리뷰 단건 조회 관련 userId 변경
[기존] 리뷰를 조회하는 userId의 프로필 정보를 조회하고 있었습니다.
[변경 후] 조회 대상인 리뷰의 reviewerId를 통해 프로필 정보를 조회합니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #68 

## 🖇️ 기타