### PR TITLE
!HOTFIX: 리뷰 단건 조회 nullable 체크

### DIFF
--- a/src/main/java/com/storix/storix_api/domains/review/application/usecase/WorksDetailReviewUseCase.java
+++ b/src/main/java/com/storix/storix_api/domains/review/application/usecase/WorksDetailReviewUseCase.java
@@ -41,7 +41,9 @@ public class WorksDetailReviewUseCase {
     }
 
     // 리뷰 단건 조회
-    public CustomResponse<DetailedReviewInfoWithProfile> getReviewDetail(Long userId, Long reviewId) {
+    public CustomResponse<DetailedReviewInfoWithProfile> getReviewDetail(AuthUserDetails authUserDetails, Long reviewId) {
+
+        Long userId = (authUserDetails != null) ? authUserDetails.getUserId() : null;
 
         DetailedReviewInfoWithProfile result = reviewService.findReviewDetail(userId, reviewId);
         return CustomResponse.onSuccess(SuccessCode.WORKS_DETAIL_REVIEW_DETAIL_LOAD_SUCCESS, result);

--- a/src/main/java/com/storix/storix_api/domains/review/controller/ReviewController.java
+++ b/src/main/java/com/storix/storix_api/domains/review/controller/ReviewController.java
@@ -65,7 +65,7 @@ public class ReviewController {
             @PathVariable @NotNull Long reviewId
     ) {
         return ResponseEntity.ok()
-                .body(worksDetailReviewUseCase.getReviewDetail(authUserDetails.getUserId(), reviewId));
+                .body(worksDetailReviewUseCase.getReviewDetail(authUserDetails, reviewId));
     }
 
     @Operation(summary = "리뷰 좋아요", description = "리뷰 id로 좋아요를 토글링하는 api 입니다. 좋아요 여부와 최신 좋아요 수가 반환됩니다.")


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [ ] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### 리뷰 단건 조회 nullable 체크
- 리뷰 단건 조회 API는 비로그인 유저도 접근 가능한 api이나, null 체킹 없이 userId를 꺼내고 있어 나는 NPE 문제를 수정하였습니다.

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
## 🖇️ 기타