### PR TITLE
Feat: Swagger 로그인 인증 구조 구현

### DIFF
--- a/src/main/java/com/storix/storix_api/global/config/SecurityConfig.java
+++ b/src/main/java/com/storix/storix_api/global/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.storix.storix_api.global.config;
 import com.storix.storix_api.global.security.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -17,7 +16,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;


### PR DESCRIPTION
## 💡 PR 작업 내용
- [x] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [ ] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
### Swagger 로그인 인증 구조 구현
- Security Basic Auth를 활용하여 로컬 환경을 제외한 환경에서 로그인을 유도하도록 하였습니다. 
- 로그인 정보는 브라우저에 캐싱되므로 한 번 로그인 해두면 재로그인 시도를 여러 번 하지 않아도 됩니다.

## 📸 작업 화면 (스크린샷)
- Swagger 로그인 화면
<img width="719" height="254" alt="Swagger 로그인" src="https://github.com/user-attachments/assets/ae8c0823-a6b3-4434-80d2-6f833b8365b7" />

- 로컬 yml 설정
```
spring:
  profiles:
    active: local
```

spring.profiles.active: local을 제외한 모든 profile에서 Swagger 로그인을 요구합니다.

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #108 

## 🖇️ 기타