### PR TITLE
Fix: Dockerfile 의존성 레이어 캐싱 삭제

### DIFF
--- a/STORIX-Api/Dockerfile
+++ b/STORIX-Api/Dockerfile
@@ -14,8 +14,6 @@ COPY STORIX-Domain/build.gradle ./STORIX-Domain/build.gradle
 COPY STORIX-Infrastructure/build.gradle ./STORIX-Infrastructure/build.gradle
 COPY STORIX-Api/build.gradle ./STORIX-Api/build.gradle
 
-RUN ./gradlew :STORIX-Api:dependencies --no-daemon
-
 COPY . .
 
 RUN ./gradlew :STORIX-Api:bootJar -x test --no-daemon

--- a/STORIX-Batch/Dockerfile
+++ b/STORIX-Batch/Dockerfile
@@ -14,8 +14,6 @@ COPY STORIX-Domain/build.gradle ./STORIX-Domain/build.gradle
 COPY STORIX-Infrastructure/build.gradle ./STORIX-Infrastructure/build.gradle
 COPY STORIX-Batch/build.gradle ./STORIX-Batch/build.gradle
 
-RUN ./gradlew :STORIX-Batch:dependencies --no-daemon
-
 COPY . .
 
 RUN ./gradlew :STORIX-Batch:bootJar -x test --no-daemon


### PR DESCRIPTION
## 💡 PR 작업 내용
- [ ] 기능 관련 작업
- [ ] 버그 수정
- [x] 코드 개선 및 수정
- [ ] 문서 작성
- [x] 배포
- [ ] 브랜치
- [ ] 기타 (아래에 자세한 내용 기입해 주세요)

## 📋 세부 작업 내용
모듈 의존성 레이어 캐싱 빌드 시간이 오래 걸림
-> bootJar 때 받아오므로 레이어 캐싱 삭제

## 📸 작업 화면 (스크린샷)

## 💬 리뷰 요구사항(선택)

## ⚠️ PR하기 전에 확인해 주세요.
- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## ⭐ 관련 이슈 번호 [#이슈번호]
- #110 

## 🖇️ 기타
멀티 모듈은 의존성이 많은데,
self-hosted runner 방식은 ec2에서 직접 실행하므로
ec2 t3.micro 메모리 1GB로는 ssm agent가 계속 죽는 문제 발생
-> ec2 t3.small로 업그레이드 후 배포 확인

github 기본 러너는 클라우드 서버에서 실행되고
메모리 7GB
-> self-hosted runner 방식에서 github 기본 러너로 전환하되
env 파일이 docker hub에 올라가지 않도록, docker-compose.yml, .env 파일은 ec2에 저장하고 거기로부터 꺼내올 필요가 있어 보임